### PR TITLE
(fix) Built Artifact: Support for Universal Application

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = ({ entryFile, externals, libraryName, outDir }) => ({
       type: "umd",
     },
     filename: "index.js",
+    globalObject: "this",
     path: outDir,
   },
   resolve: {


### PR DESCRIPTION
Change `library.globalObject` to use `this` in Webpack Config. This will enable usage of the library in both Web (Browsers) and Node.

Fixes: #21
Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>