### PR TITLE
(chore) Coverage: Integrate CodeCov with Test Workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,10 @@ jobs:
 
       - name: Generate Coverage Report
         run: yarn coverage
+
+      - name: Upload Coverage Report to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage
+          fail_ci_if_error: true


### PR DESCRIPTION
CodeCov will be  used as metric to report Code Coverage and Quality. It will work as Gate Keeper to incoming PRs.

Fixes: #3
Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>