### PR TITLE
(fix) Iterators: Return Named Tuples from methods

### DIFF
--- a/packages/plaintext-editor/__mocks__/editor-adapter.mock.ts
+++ b/packages/plaintext-editor/__mocks__/editor-adapter.mock.ts
@@ -65,7 +65,7 @@ const applyOperation = (operation: IPlainTextOperation) => {
   const ops = operation.entries();
 
   let index = 0;
-  let opValue: IteratorResult<[number, ITextOperation]>;
+  let opValue: IteratorResult<[index: number, operation: ITextOperation]>;
 
   while (!(opValue = ops.next()).done) {
     const [, op] = opValue.value;

--- a/packages/plaintext-editor/src/cursor.impl.ts
+++ b/packages/plaintext-editor/src/cursor.impl.ts
@@ -62,7 +62,7 @@ export class Cursor implements ICursor {
     );
   }
 
-  compose(other: Cursor): Cursor {
+  compose(other: ICursor): ICursor {
     return other;
   }
 
@@ -75,7 +75,7 @@ export class Cursor implements ICursor {
     const ops = operation.entries();
 
     let newIndex = index;
-    let opValue: IteratorResult<[number, ITextOperation]>;
+    let opValue: IteratorResult<[index: number, operation: ITextOperation]>;
 
     while (!(opValue = ops.next()).done) {
       const [, op] = opValue.value;
@@ -103,7 +103,7 @@ export class Cursor implements ICursor {
     return newIndex;
   }
 
-  transform(operation: IPlainTextOperation): Cursor {
+  transform(operation: IPlainTextOperation): ICursor {
     const newPosition: number = this._transformIndex(operation, this._position);
 
     if (this._position === this._selectionEnd) {
@@ -131,7 +131,7 @@ export class Cursor implements ICursor {
     };
   }
 
-  valueOf(): [number, number] {
+  valueOf(): [startPosition: number, endPosition: number] {
     return [this._position, this._selectionEnd];
   }
 }

--- a/packages/plaintext-editor/src/cursor.ts
+++ b/packages/plaintext-editor/src/cursor.ts
@@ -53,7 +53,7 @@ export interface ICursor {
    */
   equals(other: ICursor | null): boolean;
   /**
-   * Return the more current cursor information.
+   * Return the more recent cursor information.
    * @param other - Another Cursor Object.
    */
   compose(other: ICursor): ICursor;
@@ -73,5 +73,5 @@ export interface ICursor {
   /**
    * Returns Serializable set of Primitive value of a Cursor.
    */
-  valueOf(): [number, number];
+  valueOf(): [startPosition: number, endPosition: number];
 }

--- a/packages/plaintext-editor/src/wrapped-operation.impl.ts
+++ b/packages/plaintext-editor/src/wrapped-operation.impl.ts
@@ -107,7 +107,7 @@ export class WrappedOperation implements IWrappedOperation {
   }
 
   /* istanbul ignore next */
-  entries(): IterableIterator<[number, ITextOperation]> {
+  entries(): IterableIterator<[index: number, operation: ITextOperation]> {
     return this._operation.entries();
   }
 

--- a/packages/plaintext/src/text-operation.impl.ts
+++ b/packages/plaintext/src/text-operation.impl.ts
@@ -199,7 +199,7 @@ export class PlainTextOperation implements IPlainTextOperation {
     return clone;
   }
 
-  entries(): IterableIterator<[number, ITextOperation]> {
+  entries(): IterableIterator<[index: number, operation: ITextOperation]> {
     return this._ops.entries();
   }
 
@@ -449,9 +449,9 @@ export class PlainTextOperation implements IPlainTextOperation {
    * @param opIterator - Iterator Protocol Object containing Text Operation
    */
   protected _nextTextOp(
-    opIterator: IterableIterator<[number, ITextOperation]>
+    opIterator: IterableIterator<[index: number, operation: ITextOperation]>
   ): ITextOperation | null {
-    const opIteratorResult: [number, ITextOperation] | void =
+    const opIteratorResult: [index: number, operation: ITextOperation] | void =
       opIterator.next().value;
 
     return opIteratorResult ? opIteratorResult[1] : null;

--- a/packages/plaintext/src/text-operation.ts
+++ b/packages/plaintext/src/text-operation.ts
@@ -83,7 +83,7 @@ export interface IPlainTextOperation {
   /**
    * Returns an Iterator with values from Individual Operation set.
    */
-  entries(): IterableIterator<[number, ITextOperation]>;
+  entries(): IterableIterator<[index: number, operation: ITextOperation]>;
   /**
    * Apply an operation to a string, returning a new string. Throws an error if
    * there's a mismatch between the input string and the operation.


### PR DESCRIPTION
More visibility in order to make improved in-code documentation where methods are returning tuple values.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

