### PR TITLE
(fix) Monaco Adapter: Cleanup ClassName Logic for Remote Cursor

### DIFF
--- a/__tests__/monaco/__tests__/monaco-adapter.spec.ts
+++ b/__tests__/monaco/__tests__/monaco-adapter.spec.ts
@@ -250,7 +250,7 @@ describe("Test Monaco Adapter", () => {
         expect.arrayContaining([
           expect.objectContaining({
             options: expect.objectContaining({
-              className: "remote-client-_09c-cursor",
+              className: "remote-client-09c-cursor",
               isWholeLine: false,
               stickiness:
                 monaco.editor.TrackedRangeStickiness
@@ -281,7 +281,7 @@ describe("Test Monaco Adapter", () => {
         expect.arrayContaining([
           expect.objectContaining({
             options: expect.objectContaining({
-              className: "remote-client-_0ff-selection",
+              className: "remote-client-0ff-selection",
               isWholeLine: false,
               stickiness:
                 monaco.editor.TrackedRangeStickiness
@@ -314,7 +314,7 @@ describe("Test Monaco Adapter", () => {
         expect.arrayContaining([
           expect.not.objectContaining({
             options: expect.objectContaining({
-              className: "remote-client-_0ee-cursor",
+              className: "remote-client-0ee-cursor",
               isWholeLine: false,
               stickiness:
                 monaco.editor.TrackedRangeStickiness

--- a/packages/monaco/src/monaco-adapter.ts
+++ b/packages/monaco/src/monaco-adapter.ts
@@ -311,7 +311,9 @@ export class MonacoAdapter implements IEditorAdapter {
     }
 
     /** Remove non-alphanumeric characters to create valid classname */
-    const cursorColorTitle = cursorColor.replace(/\W+/g, "_");
+    const cursorColorTitle = cursorColor
+      .replaceAll(",", "_")
+      .replace(/\W+/g, "");
     const className = `remote-client-${cursorColorTitle}`;
 
     /** Generate Style rules and add them to document */

--- a/packages/monaco/src/monaco-adapter.ts
+++ b/packages/monaco/src/monaco-adapter.ts
@@ -311,9 +311,7 @@ export class MonacoAdapter implements IEditorAdapter {
     }
 
     /** Remove non-alphanumeric characters to create valid classname */
-    const cursorColorTitle = cursorColor
-      .replaceAll(",", "_")
-      .replace(/\W+/g, "");
+    const cursorColorTitle = cursorColor.replace(/,/g, "_").replace(/\W+/g, "");
     const className = `remote-client-${cursorColorTitle}`;
 
     /** Generate Style rules and add them to document */

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,8 +10,7 @@
     "module": "es6" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
       "DOM",
-      "ES2020.Promise",
-      "ES2021.String"
+      "ES2020.Promise"
     ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,8 @@
     "module": "es6" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
       "DOM",
-      "ES2020.Promise"
+      "ES2020.Promise",
+      "ES2021.String"
     ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */


### PR DESCRIPTION
Turn ',' character into '_' and remove rest of the non-alphanumeric characters from the color string to create classname of the remote cursor/selection.

Fixes: #61
Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

