### PR TITLE
(feat) @otjs/ace: Add remote cursor/selection to Ace

### DIFF
--- a/packages/ace/src/ace-adapter.ts
+++ b/packages/ace/src/ace-adapter.ts
@@ -288,6 +288,12 @@ export class AceAdapter implements IEditorAdapter {
       return range;
     };
 
+    /** Add decoration to the Editor */
+    const decorationClassName =
+      position === selectionEnd
+        ? `${className}-cursor`
+        : `${className}-selection`;
+
     // @ts-expect-error
     cursorRange.start = this._aceDocument.createAnchor(
       cursorRange.start.row,
@@ -303,7 +309,7 @@ export class AceAdapter implements IEditorAdapter {
     // @ts-expect-error
     cursorRange.id = this._aceSession.addMarker(
       cursorRange,
-      className,
+      decorationClassName,
       "text",
       false
     );

--- a/packages/utils/__tests__/__snapshots__/styles.spec.ts.snap
+++ b/packages/utils/__tests__/__snapshots__/styles.spec.ts.snap
@@ -12,13 +12,13 @@ Array [
      */
 
     .test-class-cursor {
-      position: relative;
+      position: absolute;
       background-color: transparent;
       border-left: 2px solid #000;
     }
 
     .test-class-selection {
-      position: relative;
+      position: absolute;
       opacity: 0.5;
       background-color: #000;
       border-left: 2px solid #000;

--- a/packages/utils/src/styles.ts
+++ b/packages/utils/src/styles.ts
@@ -196,13 +196,13 @@ function getStyles({
      */
 
     .${className}-cursor {
-      position: relative;
+      position: absolute;
       background-color: transparent;
       border-left: 2px solid ${cursorColor};
     }
 
     .${className}-selection {
-      position: relative;
+      position: absolute;
       opacity: 0.5;
       background-color: ${cursorColor};
       border-left: 2px solid ${cursorColor};


### PR DESCRIPTION
This commit adds cursor and selection CSS highlighting to ace editor.

Fixes: #60

Signed-off-by: Lakshya Thakur lapstjup@gmail.com

