### PR TITLE
(feat) @otjs/firebase-ace : Update code and readme

### DIFF
--- a/examples/collaborative-editors/src/firebase-ace.ts
+++ b/examples/collaborative-editors/src/firebase-ace.ts
@@ -128,6 +128,7 @@ const onDocumentReady = (): void => {
   const databaseRef = getDatabaseRef();
 
   const fireAce = new FireAceEditor({
+    announcementDuration: Infinity,
     databaseRef,
     editor,
     userId,

--- a/packages/ace/README.md
+++ b/packages/ace/README.md
@@ -4,7 +4,7 @@
 [![Weekly Downloads](https://img.shields.io/npm/dw/@otjs/ace)](https://www.npmjs.com/package/@otjs/ace)
 [![Minified Zipped Size](https://img.shields.io/bundlephobia/minzip/@otjs/ace)](https://www.npmjs.com/package/@otjs/ace)
 [![Types](https://img.shields.io/npm/types/@otjs/ace)](https://www.npmjs.com/package/@otjs/ace)
-[![License](https://img.shields.io/npm/l/@otjs/ace)](https://github.com/Progyan1997/Operational-Transformation/blob/main/packages/monaco/LICENSE)
+[![License](https://img.shields.io/npm/l/@otjs/ace)](https://github.com/Progyan1997/Operational-Transformation/blob/main/packages/ace/LICENSE)
 [![Dependencies](https://img.shields.io/librariesio/release/npm/@otjs/ace)](https://www.npmjs.com/package/@otjs/ace)
 [![Dependents](https://img.shields.io/librariesio/dependents/npm/@otjs/ace)](https://www.npmjs.com/package/@otjs/ace)
 [![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/npm/@otjs/ace)](https://github.com/Progyan1997/Operational-Transformation/blob/main/.github/SECURITY.md)
@@ -44,7 +44,8 @@ Make sure to install all the peer dependencies beforehand:
 import { AceAdapter } from "@otjs/ace";
 
 const aceAdapter = new AceAdapter({
-  editor:                   // Monaco Editor Instance
+  editor:                   // Ace Editor Instance
+  announcementDuration:     // Duration (in ms) of User Name Announcement beside Cursor (optional)
   bindEvents:               // Boolean on whether or not to emit events from Adapter (optional)
 });
 ```
@@ -69,4 +70,4 @@ See [Contributing Guidelines](https://github.com/Progyan1997/Operational-Transfo
 
 ## License
 
-This project is licensed under the terms of the MIT license, see [LICENSE](https://github.com/Progyan1997/Operational-Transformation/blob/main/packages/monaco/LICENSE) for more details.
+This project is licensed under the terms of the MIT license, see [LICENSE](https://github.com/Progyan1997/Operational-Transformation/blob/main/packages/ace/LICENSE) for more details.

--- a/packages/firebase-ace/README.md
+++ b/packages/firebase-ace/README.md
@@ -44,7 +44,8 @@ import { FireAceEditor } from "@otjs/firebase-ace";
 
 const fireAce = new FireAceEditor({
   databaseRef:            // Database Reference in Firebase Realtime DB
-  editor:                 // Monaco Editor instance
+  editor:                 // Ace Editor instance
+  announcementDuration:   // Duration to hide Cursor tooltip (optional)
   userId:                 // Unique Identifier for current user
   userColor:              // Unique Color Code for current user
   userName:               // Human readable Name or Short Name (optional)

--- a/packages/firebase-ace/src/firebase-ace.impl.ts
+++ b/packages/firebase-ace/src/firebase-ace.impl.ts
@@ -52,6 +52,7 @@ export class FireAceEditor implements IFireAceEditor {
   protected _userName: string | null = null;
 
   constructor({
+    announcementDuration,
     editor,
     databaseRef,
     userId,
@@ -65,6 +66,7 @@ export class FireAceEditor implements IFireAceEditor {
       userName,
     });
     this._editorAdapter = new AceAdapter({
+      announcementDuration,
       editor,
       bindEvents: true,
     });


### PR DESCRIPTION
This commit adds the `announcementDuration` support to `firebase-ace` API along with README updates for both `ace` and `firebase-ace`.

Fixes: #83
Signed-off-by: Lakshya Thakur lapstjup@gmail.com

